### PR TITLE
Make Docker image smaller + some fixes

### DIFF
--- a/certbot.sh
+++ b/certbot.sh
@@ -29,7 +29,7 @@ fi
 #Let's Encrypt has a certificates per registered domain (20 per week) and a names per certificate (100 subdomains) limit
 #so we should create ONE certificiates for a certain domain and add all their subdomains (max 100!)
 
-for var in $(env | grep 'DOMAIN_' | sed  -e 's/=.*//'); do
+for var in $(env | grep -P 'DOMAIN_\d+' | sed  -e 's/=.*//'); do
   cur_domains=${!var};
 
   declare -a arr=$cur_domains;
@@ -75,9 +75,9 @@ done
 
 #prepare renewcron
 if [ "$CERTBOTMODE" ]; then
-  printf "SHELL=/bin/sh\nPATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin\nPROXY_ADDRESS=$PROXY_ADDRESS\nCERTBOTMODE=$CERTBOTMODE\n" > /etc/cron.d/renewcron 
+  printf "SHELL=/bin/sh\nPATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin\nPROXY_ADDRESS=$PROXY_ADDRESS\nCERTBOTMODE=$CERTBOTMODE\n" > /etc/cron.d/renewcron
 else
-  printf "SHELL=/bin/sh\nPATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin\nPROXY_ADDRESS=$PROXY_ADDRESS\n" > /etc/cron.d/renewcron 
+  printf "SHELL=/bin/sh\nPATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin\nPROXY_ADDRESS=$PROXY_ADDRESS\n" > /etc/cron.d/renewcron
 fi
 
 

--- a/servicestart
+++ b/servicestart
@@ -11,4 +11,4 @@ printf "Starting Docker Flow: Let's Encrypt\n"
 
 printf "\033[0;31mStarting supervisord (which starts and monitors cron) \033[0m\n"
 
-/usr/bin/supervisord -c etc/supervisor/conf.d/supervisord.conf
+/usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
- cleanup whitespaces
- use absolute paths to supervisor config and certbot-auto download path
- do apt-get install at once
- cleanup apt after doing work (image size: 453MB -> 415MB)
- remove wget and use only curl to downloading certbot-auto (image size: 415MB -> 414MB)
- remove gcc and *-dev packages after they are used by certbot bootstrap (image size: size 414MB -> 267MB)